### PR TITLE
Allows flask.jsonify to return status codes and headers

### DIFF
--- a/flask_classful.py
+++ b/flask_classful.py
@@ -204,11 +204,13 @@ class FlaskView(object):
                     return response
 
             response = view(**request.view_args)
-            code, headers = 200, {}
+            code, headers = None, None
+
             if isinstance(response, tuple):
                 response, code, headers = unpack(response)
 
             if not isinstance(response, Response):
+
                 if not cls.representations:
                     # No representations defined, then the default is to just output
                     # what the view function returned as a response
@@ -227,6 +229,12 @@ class FlaskView(object):
                         # TODO(hoatle): or just make_response?
                         response = cls.representations[list(cls.representations.keys())[0]](
                             response, code, headers)
+
+            # If the header or code is set, regenerate the response
+            elif any(x is not None for x in (code, headers)):
+                # A response can be passed into `make_response` and it will set
+                # the key appropriately
+                response = make_response(response, code, headers)
 
             after_view_name = "after_" + name
             if hasattr(i, after_view_name):

--- a/test_classful/test_blueprints.py
+++ b/test_classful/test_blueprints.py
@@ -1,11 +1,14 @@
+import json
+
 from flask import Flask, Blueprint
-from .view_classes import BasicView, IndexView
+from .view_classes import BasicView, IndexView, JSONifyTestView
 from nose.tools import *
 
 app = Flask("blueprints")
 bp = Blueprint("bptest", "bptest")
 BasicView.register(bp)
 IndexView.register(bp)
+JSONifyTestView.register(bp)
 app.register_blueprint(bp)
 
 client = app.test_client()
@@ -73,6 +76,29 @@ def test_bp_url_prefix():
     resp = client.get('/foo/')
     eq_(b"Index", resp.data)
 
+def test_jsonify_normal_index():
+    resp = client.get('/jsonify')
+    eq_(resp.status_code, 200)
+    eq_(json.loads(resp.data), dict(success=True))
 
+def test_jsonify_post_custom_status_code():
+    resp = client.post('/jsonify')
+    eq_(resp.status_code, 201)
+    eq_(json.loads(resp.data), dict(success=True))
 
+def test_jsonify_not_found():
+    resp = client.get('/jsonify/not-found')
+    eq_(resp.status_code, 404)
+    eq_(json.loads(resp.data), dict(success=False))
 
+def test_custom_header():
+    resp = client.get('/jsonify/custom-header')
+    eq_(resp.status_code, 418)
+    eq_(resp.headers['X-TEAPOT'], '1')
+    eq_(json.loads(resp.data), dict(success=True))
+
+def test_normal_jsonify():
+    resp = client.get('/jsonify/normal')
+    eq_(resp.status_code, 200)
+    eq_(resp.headers != None, True)
+    eq_(json.loads(resp.data), dict(success=True))

--- a/test_classful/view_classes.py
+++ b/test_classful/view_classes.py
@@ -1,3 +1,4 @@
+from flask import jsonify
 from flask_classful import FlaskView, route
 from functools import wraps
 
@@ -334,4 +335,35 @@ class OverrideInheritedTrailingSlashView(TrailingSlashView):
         return "Index"
 
 
+class JSONifyTestView(FlaskView):
+    route_base = '/jsonify'
+    trailing_slash = False
+
+    def index(self):
+        return jsonify(dict(
+            success=True
+        )), 200
+
+    def post(self):
+        return jsonify(dict(
+            success=True
+        )), 201
+
+    @route('/not-found', methods=['GET'])
+    def not_found(self):
+        return jsonify(dict(
+            success=False
+        )), 404
+
+    @route('/custom-header', methods=['GET'])
+    def custom_header(self):
+        return jsonify(dict(
+            success=True
+        )), 418, {'X-TEAPOT': '1'}
+
+    @route('/normal')
+    def normal_jsonify(self):
+        return jsonify(dict(
+            success=True
+        ))
 


### PR DESCRIPTION
Recently, we switched from Flask Classy to Flask Classful and discovered that all our routes using `flask.jsonify` with custom headers and status codes weren't working. For example:

```python
def post(self):
    return jsonify({"success": True}), 201, {"X-CUSTOM-HEADER": "1"}
```

would return the proper JSON response but would be missing the headers and status code. Currently, we've had to change all those routes to:

```python
def post(self):
    return make_response(jsonify({"success": True}), 201, {"X-CUSTOM-HEADER": "1"})
```

This is a definite regression from Flask Classy and this PR remedies that.

Shoutout to @hjc1710 for pair programming this with me.