### PR TITLE
Small changes to enable using custom decorators in FlaskView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ pip-log.txt
 .idea/*
 .idea/libraries/sass_stdlib.xml
 
+# Vim
+*.swp
+
 # Distribution
 dist/*
 Flask_Classful.egg-info/*

--- a/flask_classful.py
+++ b/flask_classful.py
@@ -167,14 +167,19 @@ class FlaskView(object):
                         methods=methods, subdomain=subdomain, **rule_options)
 
                 else:
+                    methods = getattr(cls, 'default_methods', ["GET"])
+
                     if cls.method_dashified is True:
                         name = _dashify_underscore(name)
+
                     route_str = '/{0!s}/'.format(name)
                     if not cls.trailing_slash:
                         route_str = route_str.rstrip('/')
+
                     rule = cls.build_rule(route_str, value)
                     app.add_url_rule(
-                        rule, route_name, proxy, subdomain=subdomain, **rule_options)
+                        rule, route_name, proxy, subdomain=subdomain,
+                        methods=methods, **rule_options)
             except DecoratorCompatibilityError:
                 raise DecoratorCompatibilityError(
                     "Incompatible decorator detected on {0!s} in class {1!s}"

--- a/flask_classful.py
+++ b/flask_classful.py
@@ -328,7 +328,7 @@ class FlaskView(object):
         if hasattr(cls, 'base_args'):
             ignored_rule_args += cls.base_args
 
-        if method:
+        if method and getattr(cls, 'inspect_args', True):
             argspec = get_true_argspec(method)
             args = argspec[0]
             query_params = argspec[3]  # All default args should be ignored

--- a/test_classful/test_default_methods.py
+++ b/test_classful/test_default_methods.py
@@ -1,0 +1,24 @@
+from flask import Flask
+from .view_classes import DefaultMethodsView, NoDefaultMethodsView
+from nose.tools import eq_
+
+app = Flask('default_methods')
+
+DefaultMethodsView.register(app)
+NoDefaultMethodsView.register(app)
+
+
+def test_default_methods():
+    client = app.test_client()
+    resp = client.get('/default-methods/foo/')
+    eq_(b"GET", resp.data)
+    resp = client.post('/default-methods/foo/')
+    eq_(b"POST", resp.data)
+
+
+def test_no_default_methods():
+    client = app.test_client()
+    resp = client.get('/no-default-methods/foo/')
+    eq_(b"GET", resp.data)
+    resp = client.post('/no-default-methods/foo/')
+    eq_(resp.status_code, 405)

--- a/test_classful/test_inspect_args.py
+++ b/test_classful/test_inspect_args.py
@@ -1,6 +1,9 @@
+import sys
 from flask import Flask
 from .view_classes import InspectArgsView, NoInspectArgsView
 from nose.tools import eq_
+
+_py2 = sys.version_info[0] == 2
 
 app = Flask('inspect_args')
 
@@ -11,7 +14,10 @@ NoInspectArgsView.register(app)
 def test_inspect_args():
     client = app.test_client()
     resp = client.get('/inspect-args/foo/123/456')
-    eq_(b"foo unicode(123) unicode(456) int(678)", resp.data)
+    expected = b"foo str(123) str(456) int(678)"
+    if _py2:
+        expected = b"foo unicode(123) unicode(456) int(678)"
+    eq_(expected, resp.data)
 
 
 def test_no_inspect_args():

--- a/test_classful/test_inspect_args.py
+++ b/test_classful/test_inspect_args.py
@@ -1,0 +1,20 @@
+from flask import Flask
+from .view_classes import InspectArgsView, NoInspectArgsView
+from nose.tools import eq_
+
+app = Flask('inspect_args')
+
+InspectArgsView.register(app)
+NoInspectArgsView.register(app)
+
+
+def test_inspect_args():
+    client = app.test_client()
+    resp = client.get('/inspect-args/foo/123/456')
+    eq_(b"foo unicode(123) unicode(456) int(678)", resp.data)
+
+
+def test_no_inspect_args():
+    client = app.test_client()
+    resp = client.get('/no-inspect-args/foo/', query_string={'arg1': 123, 'arg2': 456})
+    eq_(b"foo int(123) int(456) int(678)", resp.data)

--- a/test_classful/view_classes.py
+++ b/test_classful/view_classes.py
@@ -521,7 +521,7 @@ def coerce(**kwargs):
         def wrapped(*args, **kw):
             params = request.args
             newkw = {}
-            for k, func in kwargs.iteritems():
+            for k, func in kwargs.items():
                 if not k in params:
                     continue
                 v = params[k]

--- a/test_classful/view_classes.py
+++ b/test_classful/view_classes.py
@@ -541,3 +541,16 @@ class NoInspectArgsView(FlaskView):
             type(arg2).__name__, arg2,
             type(kwarg1).__name__, kwarg1
         )
+
+
+class DefaultMethodsView(FlaskView):
+    default_methods= ['GET', 'POST']
+
+    def foo(self):
+        return request.method
+
+
+class NoDefaultMethodsView(FlaskView):
+
+    def foo(self):
+        return request.method


### PR DESCRIPTION
These changes allow me to remove most of the boilerplate use of @route as well as use custom decorators to coerce arguments to view functions.
