### PR TITLE
skip representation matching if a response returned

### DIFF
--- a/flask_classful.py
+++ b/flask_classful.py
@@ -16,7 +16,8 @@ import sys
 import functools
 import inspect
 from werkzeug.routing import parse_rule
-from flask import request, Response, make_response
+from flask import request, make_response
+from flask.wrappers import ResponseBase
 import re
 
 _py2 = sys.version_info[0] == 2
@@ -234,7 +235,7 @@ class FlaskView(object):
             if isinstance(response, tuple):
                 response, code, headers = unpack(response)
 
-            if not isinstance(response, Response):
+            if not isinstance(response, ResponseBase):
 
                 if not cls.representations:
                     # No representations defined, then the default is to just output

--- a/test_classful/test_representations.py
+++ b/test_classful/test_representations.py
@@ -1,4 +1,4 @@
-from flask import Flask, make_response
+from flask import Flask, make_response, redirect
 from flask_classful import FlaskView
 import json
 from nose.tools import *
@@ -77,6 +77,9 @@ class RepresentationView(FlaskView):
     def delete(self, obj_id):
         return response_delete
 
+    def redirect(self):
+        return redirect("http://google.com")
+
 app = Flask("representations")
 RepresentationView.register(app)
 
@@ -104,3 +107,8 @@ def test_put_representation():
 def test_delete_representation():
     resp = client.delete("/representation/1")
     eq_(json.dumps(response_delete), resp.data.decode('ascii'))
+
+def test_skip_representation_matching_if_response_is_returned():
+    resp = client.get("/representation/redirect/")
+    assert resp.status_code == 302
+    assert resp.location == "http://google.com"


### PR DESCRIPTION
There is this logic in `proxy` that if the returned value from the view function is a `flask.Response`, then no representation matching is done. 
However, there can be cases when a `werkzeug.wrappers.Response`(also named `flask.wrappers.ResponseBase`) is returned, like `return redirect('/')`.
Of course you could use `redirect('/', Response=flask.Response)`, but that can be cumbersome.

This fix ensures all instances of werkzeug Response are properly matched.