### PR TITLE
determine url variable converter from type hints in py3

### DIFF
--- a/test_classful_py3/test_type_hints.py
+++ b/test_classful_py3/test_type_hints.py
@@ -1,4 +1,4 @@
-import json
+from uuid import UUID
 from flask import Flask
 from flask_classful import FlaskView, route
 from nose.tools import *
@@ -18,6 +18,14 @@ class TypingView(FlaskView):
     def patch(self, id: str) -> str:
         return "Patch"
 
+    def int(self, arg: int):
+        return str(arg)
+
+    def float(self, arg: float):
+        return str(arg)
+
+    def uuid(self, arg: UUID):
+        return str(arg)
 
 app = Flask('typing-app')
 TypingView.register(app)
@@ -37,3 +45,18 @@ def test_post():
 def test_patch():
     resp = client.patch('/typing/123')
     eq_(b"Patch", resp.data)
+
+
+def test_url_converter():
+    for type_, wrong_var, correct_var in [
+        ('int', 'asdfsdf', '1'),
+        ('float', 'sdfad', '1.1'),
+        ('uuid', '10', '1f5018ba-1a86-4f7f-a6c5-596674562f36')
+    ]:
+        url = '/typing/{}/{}'
+        resp = client.get(url.format(type_, wrong_var))
+        # should not match the endpoint if url variable type mismatches
+        eq_(resp.status_code, 404)
+        resp = client.get(url.format(type_, correct_var))
+        eq_(resp.status_code, 200)
+        eq_(bytes(correct_var, 'utf-8'), resp.data)


### PR DESCRIPTION
In python 3, if type hints are given in the view function, it is possible to determine the url variable converter.
Currently, to set the type of a variable to be `int`, you have to use `route`:
```py
Class TestView(FlaskView):

    @route('/<int:id>')
    def get(self, id):
        return 'type of id is {}'.format(type(id))
```

Now with type hints, you can just do this:
```py
Class TestView(FlaskView):

    def get(self, id: int):
        return 'type of id is {}'.format(type(id))
```
Well, because why not.
