### PR TITLE
Add options passing to `werkzeug.Routing.Rule` from register function

### DIFF
--- a/flask_classful.py
+++ b/flask_classful.py
@@ -74,7 +74,7 @@ class FlaskView(object):
 
     @classmethod
     def register(cls, app, route_base=None, subdomain=None, route_prefix=None,
-                 trailing_slash=None, method_dashified=None, base_class=None):
+                 trailing_slash=None, method_dashified=None, base_class=None, **rule_options):
         """Registers a FlaskView class for use with a specific instance of a
         Flask app. Any methods not prefixes with an underscore are candidates
         to be routed and will have routes registered when this method is
@@ -97,6 +97,8 @@ class FlaskView(object):
         :param method_dashified: An option to dashify method name from
                                  some_route to /some-route/ route instead of
                                  default /some_route/
+        :param rule_options: The options are passed to 
+                                :class:`~werkzeug.routing.Rule` object.
         """
 
         if cls is FlaskView:
@@ -162,7 +164,7 @@ class FlaskView(object):
                         rule = rule.rstrip("/")
                     app.add_url_rule(
                         rule, route_name, proxy,
-                        methods=methods, subdomain=subdomain)
+                        methods=methods, subdomain=subdomain, **rule_options)
 
                 else:
                     if cls.method_dashified is True:
@@ -172,7 +174,7 @@ class FlaskView(object):
                         route_str = route_str.rstrip('/')
                     rule = cls.build_rule(route_str, value)
                     app.add_url_rule(
-                        rule, route_name, proxy, subdomain=subdomain)
+                        rule, route_name, proxy, subdomain=subdomain, **rule_options)
             except DecoratorCompatibilityError:
                 raise DecoratorCompatibilityError(
                     "Incompatible decorator detected on {0!s} in class {1!s}"

--- a/test_classful/test_rule_options.py
+++ b/test_classful/test_rule_options.py
@@ -1,0 +1,78 @@
+from .view_classes import BasicView, IndexView
+from flask import Flask
+from nose.tools import eq_
+
+app = Flask("rules_options")
+BasicView.register(app, strict_slashes=False)
+IndexView.register(app, strict_slashes=False)
+
+client = app.test_client()
+
+def test_rule_options_index():
+    resp = client.get("/basic/")
+    eq_(b"Index", resp.data)
+
+    resp = client.get("/basic")
+    eq_(b"Index", resp.data)
+
+
+def test_rule_options_get():
+    resp = client.get("/basic/1234/")
+    eq_(resp.status_code, 404)
+    eq_(b"Get 1234", resp.data)
+
+    resp = client.get("/basic/1234")
+    eq_(resp.status_code, 404)
+    eq_(b"Get 1234", resp.data)
+
+
+def test_rule_options_put():
+    resp = client.put("/basic/1234/")
+    eq_(resp.status_code, 403)
+    eq_(resp.headers['say'], 'hello')
+    eq_(b"Put 1234", resp.data)
+
+    resp = client.put("/basic/1234")
+    eq_(resp.status_code, 403)
+    eq_(resp.headers['say'], 'hello')
+    eq_(b"Put 1234", resp.data)
+
+
+def test_rule_options_patch():
+    resp = client.patch("/basic/1234/")
+    eq_(b"Patch 1234", resp.data)
+
+    resp = client.patch("/basic/1234")
+    eq_(b"Patch 1234", resp.data)
+
+
+def test_rule_options_post():
+    resp = client.post("/basic/")
+    eq_(b"Post", resp.data)
+
+    resp = client.post("/basic")
+    eq_(b"Post", resp.data)
+
+
+def test_rule_options_delete():
+    resp = client.delete("/basic/1234/")
+    eq_(b"Delete 1234", resp.data)
+
+    resp = client.delete("/basic/1234")
+    eq_(b"Delete 1234", resp.data)
+
+def test_rule_options_custom_method():
+    resp = client.get("/basic/custom_method/")
+    eq_(b"Custom Method", resp.data)
+
+    resp = client.get("/basic/custom_method")
+    eq_(b"Custom Method", resp.data)
+
+
+def test_rule_options_custom_method_with_params():
+    resp = client.get("/basic/custom_method_with_params/1234/abcd/")
+    eq_(b"Custom Method 1234 abcd", resp.data)
+
+    resp = client.get("/basic/custom_method_with_params/1234/abcd")
+    eq_(b"Custom Method 1234 abcd", resp.data)
+


### PR DESCRIPTION
This PR makes changes to add options passing to `werkzeug.Routing.Rule` when using register function.

`flask-classful` seemed not to provide method for ignoring trailing slash.
By this changed, you can options such as `strict_slashes` passing to `werkzeug.Routing.Rule`, you can use `strict_slashes` option with flask-classful as you do with flask


In Flask, when you want to ignore trailing slash, you can write as below.

```py
from flask import Flask
app = Flask(__name__)

@app.route('/articles', methods=['POST'], strict_slashes=False)
def post_articles():
    return ""
```
When you are running the code and accessing the endpoints `/articles` and `/articles/ `, you will get the same response without 301 redirect.

`app.route` calls `app.add_url_rule` internally,  `app.add_url_rule` can pass options to `werkzeug.Routing.Rule`
By above flow, trailing slash included in url path is ignored.

I want to do same thing in `flask-classful`, so I implemented this.


## Usage

```py
from flask import Flask
from flask_classful import FlaskView

app = Flask(__name__)

class ArticlesView(FlaskView):
  def post(self):
    return ""

ArticlesView.register(app, strict_slashes=False)
```