### PR TITLE
@#72: Polish up the representations feature.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -969,11 +969,8 @@ When the ``representations`` dictionary is not empty and if the view function re
 the rest. Otherwise, ``Flask-Classful`` will try to find the best match between the accepted content
 type and the keys in the ``representations`` dictionary, and call the associated output proxy
 function to create a ``flask.wrappers.ResponseBase`` instance. If no matching output proxy function
-is found when ``Flask-Classful`` looks up, it will call the first key's value in the dictionary (This
-behavior could change in the future, maybe just return the data?).
-
-//TODO(hoatle): https://github.com/teracyhq/flask-classful/issues/72
-
+is found when ``Flask-Classful`` looks for one, then the data the view returns
+is passed straight to ``Flask's`` ``make_response`` and returned as is.
 
 This is an example where the view function returns a ``flask.wrappers.ResponseBase`` instance,
 skipping the ``representations`` system entirely::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -988,6 +988,23 @@ skipping the ``representations`` system entirely::
             return redirect("http://flask-classful.teracy.org")
 
 
+To define a default representation that is used when no other matches are
+found, you can add the ``flask-classful/default`` mimetype to your
+representations dictionary, like so::
+
+    # views.py
+
+    from flask_classful import FlaskView
+    from .representations import output_default, output_json
+
+    class CoolDefaultView(FlaskView):
+        representations = {'application/json': output_json,
+                           'flask-classful/default': output_default}
+
+        def post(self):
+            return {'defaults': 'are cool, yo'}
+
+
 Type Hints Support for Python 3
 -------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -967,7 +967,7 @@ By default, the ``representations`` class attribute is an empty dictionary.
 When the ``representations`` dictionary is not empty and if the view function returns a
 ``flask.wrappers.ResponseBase`` instance, it will be returned immediately to ``Flask`` to handle
 the rest. Otherwise, ``Flask-Classful`` will try to find the best match between the accepted content
-type and the keys in the ``representations`` dictionary, and call the associated output proxy
+types and the keys in the ``representations`` dictionary, and call the associated output proxy
 function to create a ``flask.wrappers.ResponseBase`` instance. If no matching output proxy function
 is found when ``Flask-Classful`` looks for one, then the data the view returns
 is passed straight to ``Flask's`` ``make_response`` and returned as is.
@@ -1003,6 +1003,15 @@ representations dictionary, like so::
 
         def post(self):
             return {'defaults': 'are cool, yo'}
+
+.. note::
+    "Find the best match" means comparing the accepted mimetypes and their
+    q-factor weighting to the list of representation mimetypes. That is, Flask
+    Classful does no special heuristics in finding this best match. For more
+    information, see `this MDN article on the Accept
+    header<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept>`_
+    or `this snippet<http://flask.pocoo.org/snippets/45/>`_ about Werkzeug's
+    ``best_match`` helper.
 
 
 Type Hints Support for Python 3

--- a/flask_classful.py
+++ b/flask_classful.py
@@ -288,12 +288,9 @@ class FlaskView(object):
                             resp_representation
                         ](response, code, headers)
                     else:
-                        # Nothing adequate found, make the response any one of
-                        # the representations defined
-                        # TODO(hoatle): or just make_response?
-                        response = cls.representations[
-                            list(cls.representations.keys())[0]
-                        ](response, code, headers)
+                        # Nothing adequate found, return what the view function
+                        # gave us for predictability
+                        response = make_response(response, code, headers)
 
             # If the header or code is set, regenerate the response
             elif any(x is not None for x in (code, headers)):

--- a/flask_classful.py
+++ b/flask_classful.py
@@ -287,6 +287,10 @@ class FlaskView(object):
                         response = cls.representations[
                             resp_representation
                         ](response, code, headers)
+                    elif 'flask-classful/default' in cls.representations:
+                        response = cls.representations['flask-classful/default'](
+                            response, code, headers
+                        )
                     else:
                         # Nothing adequate found, return what the view function
                         # gave us for predictability

--- a/test_classful/test_representations.py
+++ b/test_classful/test_representations.py
@@ -1,7 +1,7 @@
-from flask import Flask, make_response, redirect
+from flask import Flask, make_response, redirect, request
 from flask_classful import FlaskView
 import json
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
 
 def output_json(data, code, headers=None):
@@ -53,7 +53,8 @@ response_delete = {
     'input_required': 'DELETE'
 }
 
-input_headers = [('Content-Type', 'application/json')]
+input_headers = [('Content-Type', 'application/json'),
+                 ('Accept', 'application/json')]
 input_data = {'input_required': 'required'}
 
 
@@ -76,6 +77,11 @@ class RepresentationView(FlaskView):
     def delete(self, obj_id):
         return response_delete
 
+    def mirror(self):
+        out = request.args.get('q', 'placeholder')
+
+        return out, 201, {'Content-Type': 'foo/bar'}
+
     def redirect(self):
         return redirect("http://google.com")
 
@@ -86,12 +92,12 @@ client = app.test_client()
 
 
 def test_index_representation():
-    resp = client.get("/representation/")
+    resp = client.get("/representation/", headers=input_headers)
     eq_(json.dumps([response_1, response_2]), resp.data.decode('ascii'))
 
 
 def test_get_representation():
-    resp = client.get("/representation/1/")
+    resp = client.get("/representation/1/", headers=input_headers)
     eq_(json.dumps(response_get), resp.data.decode('ascii'))
     resp = client.get("/representation/1")
     eq_(resp.status_code, 301)
@@ -119,7 +125,8 @@ def test_put_representation():
 
 
 def test_delete_representation():
-    resp = client.delete("/representation/1/")
+    resp = client.delete("/representation/1/",
+                         headers=input_headers)
     eq_(json.dumps(response_delete), resp.data.decode('ascii'))
     resp = client.delete("/representation/1")
     eq_(resp.status_code, 301)
@@ -127,5 +134,15 @@ def test_delete_representation():
 
 def test_skip_representation_matching_if_response_is_returned():
     resp = client.get("/representation/redirect/")
-    assert resp.status_code == 302
-    assert resp.location == "http://google.com"
+    eq_(resp.status_code, 302)
+    eq_(resp.location, "http://google.com")
+
+
+def test_representations_no_match_return_string():
+    """If no matching Accept is found, Classful uses what view returns."""
+    resp = client.get("/representation/mirror/", query_string={'q': 'foobar'},
+                      headers={'Accept': 'foo/bar'})
+
+    eq_(resp.data, b'foobar')
+    eq_(resp.headers['Content-Type'], 'foo/bar')
+    eq_(resp.status_code, 201)


### PR DESCRIPTION
Changes:

- Now if the `representations` system cannot find a matching mimetype, it will merely call `make_response` on what the View returned.
- Added support for a special mimetype called: `flask-classful/default` this allows you to implement a default representation that can be used if no others are found.
- Adds documentation and tests around new features.
- Better defines in the documentation what "find the best match" means.

Tests:

- All components tested.

Resolves #72.