### PR TITLE
Track registered endpoints

### DIFF
--- a/flask_classful.py
+++ b/flask_classful.py
@@ -193,13 +193,14 @@ class FlaskView(object):
                         rule, route_name, proxy, subdomain=subdomain,
                         methods=methods, **rule_options)
 
-                setattr(app.view_functions[endpoint_route_name], "_classful_meta", dict(
-                    view_func=proxy,
-                    rule=rule,
-                    route=endpoint_route_name,
-                    target=cls,
-                    methods=methods,
-                ))
+                if hasattr(app, 'view_functions'):
+                    setattr(app.view_functions[endpoint_route_name], "_classful_meta", dict(
+                        view_func=proxy,
+                        rule=rule,
+                        route=endpoint_route_name,
+                        target=cls,
+                        methods=methods,
+                    ))
             except DecoratorCompatibilityError:
                 raise DecoratorCompatibilityError(
                     "Incompatible decorator detected on {0!s} in class {1!s}"

--- a/flask_classful.py
+++ b/flask_classful.py
@@ -16,6 +16,7 @@ from werkzeug.routing import parse_rule
 from flask import request, make_response
 from flask.wrappers import ResponseBase
 import re
+from flask_apispec.views import MethodResource
 
 _py2 = sys.version_info[0] == 2
 
@@ -134,6 +135,12 @@ class FlaskView(object):
 
         members = get_interesting_members(base_class, cls)
 
+        # view = cls.as_view(cls.__name__)
+        view_name = cls
+        if view_name not in app._resource_views:
+            app._resource_views[view_name] = list()
+        # app._resource_views.append(view)
+
         for name, value in members:
             proxy = cls.make_proxy_method(name)
             route_name = cls.build_route_name(name)
@@ -185,15 +192,16 @@ class FlaskView(object):
                         route_str = route_str.rstrip('/')
                     rule = cls.build_rule(route_str, value)
                     if cls.trailing_slash is True and rule.endswith('/') is False:
-                        rule = '{0!s}/'.format(rule)
+                        rule = '{0!s}/'.fromat(rule)
                     # print '3 - {0!s}'.format(rule)
                     app.add_url_rule(
                         rule, route_name, proxy, subdomain=subdomain,
                         methods=methods, **rule_options)
 
-                app._resource_view_endpoints.append(dict(
-                    target=value,
+                app._resource_views[view_name].append(dict(
+                    method=proxy,
                     endpoint=endpoint_route_name,
+                    target=cls,
                 ))
             except DecoratorCompatibilityError:
                 raise DecoratorCompatibilityError(

--- a/flask_classful.py
+++ b/flask_classful.py
@@ -134,13 +134,6 @@ class FlaskView(object):
 
         members = get_interesting_members(base_class, cls)
 
-        if not hasattr(app, '_classful_resource_views'):
-            setattr(app, '_classful_resource_views', dict())
-
-        view_name = cls
-        if view_name not in app._classful_resource_views:
-            app._classful_resource_views[view_name] = list()
-
         for name, value in members:
             proxy = cls.make_proxy_method(name)
             route_name = cls.build_route_name(name)
@@ -200,7 +193,7 @@ class FlaskView(object):
                         rule, route_name, proxy, subdomain=subdomain,
                         methods=methods, **rule_options)
 
-                app._classful_resource_views[view_name].append(dict(
+                setattr(app.view_functions[endpoint_route_name], "_classful_meta", dict(
                     view_func=proxy,
                     rule=rule,
                     route=endpoint_route_name,

--- a/flask_classful.py
+++ b/flask_classful.py
@@ -137,6 +137,8 @@ class FlaskView(object):
         for name, value in members:
             proxy = cls.make_proxy_method(name)
             route_name = cls.build_route_name(name)
+            endpoint_route_name = route_name
+
             try:
                 if hasattr(value, "_rule_cache") and name in value._rule_cache:
                     for idx, cached_rule in enumerate(value._rule_cache[name]):
@@ -154,6 +156,7 @@ class FlaskView(object):
                         else:
                             endpoint = "{0!s}_{1:d}".format(route_name, idx)
                         # print '1 - {0!s}'.format(rule)
+                        endpoint_route_name = endpoint
                         app.add_url_rule(
                             rule, endpoint, proxy,
                             subdomain=subdomain, **options)
@@ -187,6 +190,11 @@ class FlaskView(object):
                     app.add_url_rule(
                         rule, route_name, proxy, subdomain=subdomain,
                         methods=methods, **rule_options)
+
+                app._resource_view_endpoints.append(dict(
+                    target=value,
+                    endpoint=endpoint_route_name,
+                ))
             except DecoratorCompatibilityError:
                 raise DecoratorCompatibilityError(
                     "Incompatible decorator detected on {0!s} in class {1!s}"

--- a/flask_classful.py
+++ b/flask_classful.py
@@ -195,7 +195,7 @@ class FlaskView(object):
                         route_str = route_str.rstrip('/')
                     rule = cls.build_rule(route_str, value)
                     if cls.trailing_slash is True and rule.endswith('/') is False:
-                        rule = '{0!s}/'.fromat(rule)
+                        rule = '{0!s}/'.format(rule)
                     # print '3 - {0!s}'.format(rule)
                     app.add_url_rule(
                         rule, route_name, proxy, subdomain=subdomain,

--- a/flask_classful.py
+++ b/flask_classful.py
@@ -16,7 +16,6 @@ from werkzeug.routing import parse_rule
 from flask import request, make_response
 from flask.wrappers import ResponseBase
 import re
-from flask_apispec.views import MethodResource
 
 _py2 = sys.version_info[0] == 2
 


### PR DESCRIPTION
Keep track of what endpoints are registered, along with rules and context.
This enables auto-generation of swagger documentation
Flask-Classful support is here: https://github.com/jmcarp/flask-apispec/pull/69