### PR TITLE
Add additional init_argument to register method

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -328,6 +328,44 @@ on a View to redirect elsewhere? Try calling ``register`` like so::
 For more information on what you can pass, see Werkzeug's own documentation for
 `werkzeug.routing.Rule <http://werkzeug.pocoo.org/docs/0.12/routing/#werkzeug.routing.Rule>`_.
 
+
+Well ... more words on ``register``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes you may want to pass additional information to the inherited ``FlaskView``
+classes. One possible solution could be to use global objects (well, you could even
+join Darth Vader on the dark side and your mom wouldn't be proud either) but this is not
+the best pattern.
+
+Instead it is possible to pass an additional parameter to the ``register`` method
+called ``init_argument``.
+
+When it is passed with a value different than ``Nothing``, ``Flask-Classful`` will
+create the inherited ``FlaskView`` instance passing this parameter to the constructor.
+
+Note that this parameter is unique, you can pass complex structures using as this
+parameter either tuples or dictionaries.
+
+Let's see an example of this additional parameter in the ``register`` method::
+
+    from flask import Flask
+    from flask_classful import FlaskView
+
+    app = Flask(__name__)
+
+    class QuotesView(FlaskView):
+        def __init__(self, my_init_argument):
+            self._my_init_argument = my_init_argument
+
+        def index(self):
+            return self._my_init_argument
+
+    QuotesView.register(app, "Fistro diodenarl de abajorl")
+
+    if __name__ == '__main__':
+        app.run()
+
+
 Using multiple routes for a single view
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test_classful/test_init_argument.py
+++ b/test_classful/test_init_argument.py
@@ -1,0 +1,22 @@
+from flask import Flask
+from .view_classes import WithInitArgument, WithoutInitArgument
+from nose.tools import eq_
+import json
+
+app = Flask("init_argument")
+WithInitArgument.register(app, init_argument = "fistro de la praderarrr")
+WithoutInitArgument.register(app)
+
+client = app.test_client()
+
+
+def test_init_argument_used():
+    resp = client.get("/with_init_argument/")
+    eq_("fistro de la praderarrr", json.loads(resp.data.decode('utf-8'))["init_argument"])
+    eq_(resp.status_code, 200)
+
+
+def test_init_argument_not_used():
+    resp = client.get("/without_init_argument/")
+    eq_("not sent", json.loads(resp.data.decode('utf-8'))["init_argument"])
+    eq_(resp.status_code, 200)

--- a/test_classful/view_classes.py
+++ b/test_classful/view_classes.py
@@ -574,3 +574,30 @@ class NoDefaultMethodsView(FlaskView):
 
     def foo(self):
         return request.method
+
+
+class WithInitArgument(FlaskView):
+    """
+    View class that receives in the constructor a parameter
+    """
+    route_base = '/with_init_argument/'
+
+    def __init__(self, init_argument):
+        self._init_argument = init_argument
+
+    def get(self):
+        return jsonify({ "init_argument": self._init_argument }), 200
+
+
+class WithoutInitArgument(FlaskView):
+    """
+    View class that does not receive in the constructor a parameter
+    For checking backwards compatibility
+    """
+    route_base = '/without_init_argument/'
+
+    def __init__(self):
+        self._init_argument = "not sent"
+
+    def get(self):
+        return jsonify({ "init_argument": self._init_argument }), 200


### PR DESCRIPTION
Sometimes it is needed to pass additional information to the inherited FlaskView classes.

As flask-classy and flask-classful are defined, the __init__ call is
intended to being created without arguments, because when instanced it
is created by just a call without parameters.

While this can be overcomed referencing the needed information from
global objects, this practice is not as clean as clearly defining and
passing the information through the constructor.

This commit adds additional init_argument to register method, optional
with default value of None, that allows to pass information in the
__init__ of the registered classes.

The implementation is fully backwards compatible, with an optional
parameter than when not provided will behave just like it before.

This maybe solves the request in teracyhq/flask-classful/issues#84