### PR TITLE
@ #94 | inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()

### DIFF
--- a/flask_classful.py
+++ b/flask_classful.py
@@ -444,9 +444,9 @@ def get_true_argspec(method):
     """
 
     try:
-        argspec = inspect.getargspec(method)
-    except ValueError:
         argspec = inspect.getfullargspec(method)
+    except AttributeError:
+        argspec = inspect.getargspec(method)
 
     args = argspec[0]
     if args and args[0] == 'self':


### PR DESCRIPTION
connect #94 