### PR TITLE
uses Response if ResponseBase is not available

### DIFF
--- a/flask_classful.py
+++ b/flask_classful.py
@@ -14,7 +14,11 @@ import inspect
 from uuid import UUID
 from werkzeug.routing import parse_rule
 from flask import request, make_response
-from flask.wrappers import ResponseBase
+try:
+    from flask.wrappers import ResponseBase
+except:
+    from flask.wrappers import Response as ResponseBase
+
 import re
 
 _py2 = sys.version_info[0] == 2


### PR DESCRIPTION
I wanted to use this extension for [Quart](http://pgjones.gitlab.io/quart/flask_ext_tutorial.html) but the problem is Quart doesn't wrap the RequestBase class. PR will use Request if RequestBase is not available. This way it is 100% backward compatible.