### PR TITLE
Add @method decorator and handling

### DIFF
--- a/flask_classful.py
+++ b/flask_classful.py
@@ -41,6 +41,20 @@ def route(rule, **options):
 
     return decorator
 
+def method(method, **options):
+    """A decorator that is used to define custom http methods on methods in
+    FlaskView subclasses.
+    """
+
+    def decorator(f):
+        if not hasattr(f, 'http_methods'):
+            f.http_methods = []
+
+        f.http_methods.append(method)
+        return f
+
+    return decorator
+
 
 class FlaskView(object):
     """Base view for any class based views implemented with Flask-Classful. Will
@@ -182,7 +196,10 @@ class FlaskView(object):
                         methods=methods, subdomain=subdomain, **rule_options)
 
                 else:
-                    methods = getattr(cls, 'default_methods', ["GET"])
+                    if hasattr(value, 'http_methods'):
+                        methods = value.http_methods
+                    else:
+                        methods = getattr(cls, 'default_methods', ["GET"])
 
                     if cls.method_dashified is True:
                         name = _dashify_underscore(name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+flask
+marshmallow
+webargs
+
 # test
 nose
 tox

--- a/test_classful/test_common.py
+++ b/test_classful/test_common.py
@@ -105,6 +105,20 @@ def test_custom_http_method():
     resp = client.post("/basic/route3")
     eq_(resp.status_code, 308)
 
+def test_method_decorator_simple():
+    resp = client.post("/basic/methoddecorated/")
+    eq_(b"POST", resp.data)
+    resp = client.post("/basic/methoddecorated")
+    eq_(resp.status_code, 308)
+
+def test_method_decorator_twice():
+    resp = client.post('/basic/methodtwicedecorated/')
+    eq_(b"POST", resp.data)
+    resp = client.patch('/basic/methodtwicedecorated/')
+    eq_(b"PATCH", resp.data)
+
+    
+
 
 def test_docstrings():
     proxy_func = app.view_functions["BasicView:index"]

--- a/test_classful/test_common.py
+++ b/test_classful/test_common.py
@@ -120,10 +120,10 @@ def test_method_decorator_twice():
 def test_method_route():
    """Test that the @method decorator does not come into play when a route
    is set explicitly"""
-   resp = client.post('/basic/route4/')
+   resp = client.post('/basic/methodroute')
    eq_(resp.status_code, 405)
-   resp = client.get('/basic/route4/')
-   eq_(b"Get route4", resp.data)
+   resp = client.get('/basic/methodroute')
+   eq_(b"GET", resp.data)
 
 
 def test_docstrings():

--- a/test_classful/test_common.py
+++ b/test_classful/test_common.py
@@ -117,7 +117,13 @@ def test_method_decorator_twice():
     resp = client.patch('/basic/methodtwicedecorated/')
     eq_(b"PATCH", resp.data)
 
-    
+def test_method_route():
+   """Test that the @method decorator does not come into play when a route
+   is set explicitly"""
+   resp = client.post('/basic/route4/')
+   eq_(resp.status_code, 405)
+   resp = client.get('/basic/route4/')
+   eq_(b"Get route4", resp.data)
 
 
 def test_docstrings():

--- a/test_classful/view_classes.py
+++ b/test_classful/view_classes.py
@@ -66,6 +66,11 @@ class BasicView(FlaskView):
     def methodtwicedecorated(self):
         return request.method
 
+    @method("POST")
+    @route("/route4")
+    def methodplusroute(self):
+        return request.method
+
 
 class SubdomainAttributeView(FlaskView):
     subdomain = "sub1"

--- a/test_classful/view_classes.py
+++ b/test_classful/view_classes.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import jsonify, request
 from flask_classful import FlaskView, route, method
 from functools import wraps
@@ -67,7 +69,7 @@ class BasicView(FlaskView):
         return request.method
 
     @method("POST")
-    @route("/route4")
+    @route("/methodroute")
     def methodplusroute(self):
         return request.method
 

--- a/test_classful/view_classes.py
+++ b/test_classful/view_classes.py
@@ -1,5 +1,5 @@
 from flask import jsonify, request
-from flask_classful import FlaskView, route
+from flask_classful import FlaskView, route, method
 from functools import wraps
 
 VALUE1 = "value1"
@@ -56,6 +56,15 @@ class BasicView(FlaskView):
     @route("/route3/", methods=['POST'])
     def custom_http_method(self):
         return "Custom HTTP Method"
+
+    @method("POST")
+    def methoddecorated(self):
+        return request.method
+
+    @method("POST")
+    @method("PATCH")
+    def methodtwicedecorated(self):
+        return request.method
 
 
 class SubdomainAttributeView(FlaskView):


### PR DESCRIPTION
Using the @method decorator, you can specify for which http method your
class method will be called. This is useful if you cannot use the
default_methods on you class because not all class methods implement the
entire list and if you do not want to use the @route decorator, which
supports method definition as well, because you do not want to lose the
flexibility of classful creating the url rules for you.