### PR TITLE
Keep reference of the view's class in the proxy function

### DIFF
--- a/flask_classful.py
+++ b/flask_classful.py
@@ -270,6 +270,9 @@ class FlaskView(object):
             return inner
         view = make_func(view)
 
+        # Keep a reference to the class for potential use inside decorators
+        view.class_ = i
+
         # Now apply the class decorator list in reverse order
         # to match member decorator order
         if cls.decorators:

--- a/test_classful/test_decorators.py
+++ b/test_classful/test_decorators.py
@@ -5,6 +5,7 @@ from .view_classes import DecoratedBoldItalicsListView
 from .view_classes import DecoratedListMemberView
 from .view_classes import DecoratedListFunctionAttributesView
 from .view_classes import DecoratedListMemberFunctionAttributesView
+from .view_classes import DecoratedAppendClassAttributeView
 from nose.tools import eq_
 
 app = Flask("decorated")
@@ -14,6 +15,7 @@ DecoratedBoldItalicsListView.register(app)
 DecoratedListMemberView.register(app)
 DecoratedListFunctionAttributesView.register(app)
 DecoratedListMemberFunctionAttributesView.register(app)
+DecoratedAppendClassAttributeView.register(app)
 client = app.test_client()
 
 
@@ -211,3 +213,8 @@ def test_decorator_list_member_function_attributes_index():
         app.view_functions[
             'DecoratedListMemberFunctionAttributesView:index'
         ].eggs)
+
+
+def test_decorator_append_class_attribute_index():
+    resp = client.get('/decorated_append_class_attribute_view/')
+    eq_(b'Index (this is a test)', resp.data)

--- a/test_classful/view_classes.py
+++ b/test_classful/view_classes.py
@@ -525,7 +525,7 @@ class DecoratedListFunctionAttributesView(FlaskView):
 class DecoratedListMemberFunctionAttributesView(FlaskView):
     """
     View class that applies an attribute to a function via a
-    decorator on the memeber function
+    decorator on the member function
     """
     route_base = '/decorated_list_member_function_attributes_view/'
     decorators = [make_italics_decorator]
@@ -539,6 +539,29 @@ class DecoratedListMemberFunctionAttributesView(FlaskView):
     def index(self):
         """Get the index"""
         return 'Index'
+
+
+def append_test_class_attribute_decorator(fn):
+    @wraps(fn)
+    def inner(*args, **kwargs):
+        test_cls_attribute = getattr(fn.class_, "test")
+        return fn(*args, **kwargs) + test_cls_attribute
+    return inner
+
+
+class DecoratedAppendClassAttributeView(FlaskView):
+    """
+    View class that appends the value of the class attribute
+    `test` to the response.
+    """
+    route_base = '/decorated_append_class_attribute_view/'
+    decorators = [append_test_class_attribute_decorator]
+
+    test = " (this is a test)"
+
+    def index(self):
+        """Get the index"""
+        return "Index"
 
 
 class InspectArgsView(FlaskView):


### PR DESCRIPTION
We are (finally) migrating a project from using flask-classy to flask-classful. One breaking change for us is this commit 686be6ef6fd09d9c1719fa89763ad09baddf7fd0 . It makes the bound instance method a function. However, we are currently using the instance to retrieve an attribute of the class when applying the decorators to run our validators so this break our code, and we have no easy way around it. Several of our big projects rely on our validation mechanism, so we cannot introduce that big of a breaking change.

This little line I added allows us to simply replace in our code
```python
view.__self__.__class__
```
by
```python
view._class
```
And therefore prevent any breaking change.
This could also be useful for anyone needing access to the class instance within their decorators.

The name is arbitrary, tell me if you think something else is more appropriate.